### PR TITLE
Allow custom timestamp format

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -145,7 +145,7 @@ class Auth extends Core
         }
 
         if (static::$settings['USE_TIMESTAMPS']) {
-            $now = (new \Leaf\Date())->tick()->now();
+            $now = (new \Leaf\Date())->tick()->format(static::$settings['TIMESTAMP_FORMAT']);
             $credentials['created_at'] = $now;
             $credentials['updated_at'] = $now;
         }
@@ -266,7 +266,7 @@ class Auth extends Core
         }
 
         if (static::$settings['USE_TIMESTAMPS']) {
-            $credentials['updated_at'] = (new \Leaf\Date())->tick()->now();
+            $credentials['updated_at'] = (new \Leaf\Date())->tick()->format(static::$settings['TIMESTAMP_FORMAT']);
         }
 
         if (count($uniques) > 0) {

--- a/src/Auth/Core.php
+++ b/src/Auth/Core.php
@@ -27,6 +27,7 @@ class Core
         'DB_TABLE' => 'users',
         'AUTH_NO_PASS' => false,
         'USE_TIMESTAMPS' => true,
+        'TIMESTAMP_FORMAT' => 'c',
         'PASSWORD_ENCODE' => null,
         'PASSWORD_VERIFY' => null,
         'PASSWORD_KEY' => 'password',


### PR DESCRIPTION
- When trying to register having USE_TIMESTAMPS to true, the insert on a mysql database fails because the default format of tick()->now() is not supported by mysql DATETIME type

- With this PR it makes the format customizable so that anyone can use the desired format according to their use case

Please try it and let me know if this makes sense, otherwise you can close it. Thanks a lot! 