### PR TITLE
Fix where clause when fetching user

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -454,7 +454,7 @@ class Auth extends Core
             return null;
         }
 
-        $user = static::$db->select($table)->where('id', static::id())->fetchAssoc();
+        $user = static::$db->select($table)->where(static::$settings['ID_KEY'], static::id())->fetchAssoc();
 
         if (count($hidden) > 0) {
             foreach ($hidden as $item) {


### PR DESCRIPTION
- When fetching a user, "id" was being used instead of ID_KEY. This leads to problems if the user database has a different column name for id