### PR TITLE
FIX: Check session exists on expireSession

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -487,6 +487,7 @@ class Auth extends Core
      */
     private static function expireSession(): bool
     {
+        self::sessionCheck();
         $sessionTtl = static::$session->get('SESSION_TTL');
 
         if (!$sessionTtl) {


### PR DESCRIPTION
## Description

- If only using the config to enable session and not the useSession() method, when calling user() without a session, an exception would be thrown