### PR TITLE
FIX: Session TTL incorrect when date string is provided in config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         }
     },
     "require-dev": {
-        "leafs/alchemy": "^1.0"
+        "leafs/alchemy": "^1.0",
+        "pestphp/pest": "^1.0 | ^2.0"
     },
     "scripts": {
         "test": "vendor/bin/pest --colors=always --coverage"

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -585,12 +585,23 @@ class Auth extends Core
      */
     private static function setSessionTtl(): void
     {
-        $sessionLifetime = is_int(static::config('SESSION_LIFETIME'))
-            ? static::config('SESSION_LIFETIME')
-            : (int) strtotime(static::config('SESSION_LIFETIME'));
+        $sessionLifetime = static::config('SESSION_LIFETIME');
 
-        if ($sessionLifetime > 0) {
-            static::$session->set('SESSION_TTL', time() + $sessionLifetime);
+        if ($sessionLifetime === 0) {
+            return;
         }
+
+        if (is_int($sessionLifetime)) {
+            static::$session->set('SESSION_TTL', time() + $sessionLifetime);
+            return;
+        }
+
+        $sessionLifetimeInTime = strtotime($sessionLifetime);
+
+        if (!$sessionLifetimeInTime) {
+            throw new \Exception('Provided string could not be converted to time');
+        }
+
+        static::$session->set('SESSION_TTL', $sessionLifetimeInTime);
     }
 }

--- a/tests/AuthSessionTest.php
+++ b/tests/AuthSessionTest.php
@@ -141,3 +141,25 @@ test('Session should expire when fetching status', function () {
     sleep(2);
     expect($auth::status())->toBeFalse();
 });
+
+test('Session lifetime should set correct session ttl when string is configured instead of timestamp', function () {
+    $auth = new \Leaf\Auth();
+    $auth::config(getAuthConfig(['SESSION_LIFETIME' => '1 day']));
+    $auth::login(['username' => 'login-user', 'password' => 'login-pass']);
+
+    expect($auth::status())->not()->toBeNull();
+
+    $timestampOneDay = 60 * 60 * 24;
+    $session = new \Leaf\Http\Session(false);
+    $sessionTtl = $session->get('SESSION_TTL');
+
+    expect($sessionTtl)->toBe(time() + $timestampOneDay);
+});
+
+test('Login should throw error when lifetime string is invalid', function () {
+    $auth = new \Leaf\Auth();
+    $auth::config(getAuthConfig(['SESSION_LIFETIME' => 'invalid string']));
+
+    expect(fn() => $auth::login(['username' => 'login-user', 'password' => 'login-pass']))
+        ->toThrow(Exception::class, 'Provided string could not be converted to time');
+});


### PR DESCRIPTION
## Description

- When passing for example '1 day' in SESSION_LIFETIME it would result in a wrong session ttl. The result would be the current time + the timestamp of tomorrow.

- Example: Let's consider the current timestamp: 1696600085 and the timestamp of tomorrow: 1696682885. The session ttl was resulting in: 3393282970