### PR TITLE
🪄 Added a check if redirect_on_register is allowed

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -142,7 +142,7 @@ class Auth extends Core
         }
 
         if (static::$settings['USE_TIMESTAMPS']) {
-            $now = (new \Leaf\Date())->tick()->format(static::$settings['TIMESTAMP_FORMAT']);
+            $now = date('Y-m-d H:i:s');
             $credentials['created_at'] = $now;
             $credentials['updated_at'] = $now;
         }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -142,7 +142,7 @@ class Auth extends Core
         }
 
         if (static::$settings['USE_TIMESTAMPS']) {
-            $now = date('Y-m-d H:i:s');
+            $now = (new \Leaf\Date())->tick()->format(static::$settings['TIMESTAMP_FORMAT']);
             $credentials['created_at'] = $now;
             $credentials['updated_at'] = $now;
         }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -200,10 +200,13 @@ class Auth extends Core
 
                 self::setUserToSession($user, $token);
 
-                exit(header('location: ' . static::config('GUARD_HOME')));
+                $redirectPath = static::config('GUARD_HOME');
             } else {
-                exit(header('location: ' . static::config('GUARD_LOGIN')));
+                $redirectPath = static::config('GUARD_LOGIN');
             }
+
+            if(static::config('REDIRECT_ON_REGISTER'))
+                exit(header('location: ' . $redirectPath));
         }
 
         $response['user'] = $user;


### PR DESCRIPTION
## Bug Fix: Added a check if redirect_on_register is allowed

### Issue

The method `register()` currently faces a limitation where it cannot return its output due to enforced redirection, impacting API-first applications/requests or those aiming to handle the method's return manually

### Details of Changes

I introduced a check to see if the `REDIRECT_ON_REGISTER` configuration option is enabled. This change ensures that the redirection after user registration only occurs if explicitly allowed by the configuration.

I modified the code block responsible for redirecting users after registration to include a conditional check for the `REDIRECT_ON_REGISTER` configuration option. If this option is enabled, the redirection will proceed; otherwise, there will be a return value

### Benefits

- **Enhanced Configurability:** By introducing this check, we provide administrators with greater control over the behaviour of the application after user registration.

### Compatibility

This change does not impact any existing features or functionalities of the application. It operates within the existing framework, ensuring seamless integration with the authentication module.

### Documentation Update

An update to the LeafMVC documentation is necessary to reflect the addition of the `REDIRECT_ON_REGISTER` configuration option within the authentication module. This ensures that users and developers are aware of this configurable behaviour and can utilize it effectively.