### PR TITLE
 Ensure find() method checks DB connection before querying

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -444,6 +444,8 @@ class Auth
      */
     public function find($id)
     {
+		$this->checkDbConnection();
+
         $userData = $this->db->select(Config::get('db.table'))->find($id);
 
         if (!$userData) {

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -444,7 +444,7 @@ class Auth
      */
     public function find($id)
     {
-		$this->checkDbConnection();
+        $this->checkDbConnection();
 
         $userData = $this->db->select(Config::get('db.table'))->find($id);
 


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description
This PR addresses an issue in the `find()` method where the method does not call `checkDBConnection()` before attempting a database query. This results in a runtime error (Call to a member function select() on null) when no DB connection is active.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

## Related Issue
Fixes #28 
<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
