### PR TITLE
chore: change fully qualified class names with uses (with rectorphp)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "require-dev": {
         "pestphp/pest": "^1.0 | ^2.0",
         "friendsofphp/php-cs-fixer": "^3.64",
-        "leafs/alchemy": "*"
+        "leafs/alchemy": "*",
+        "rector/rector": "^2.2"
     },
     "scripts": {
         "alchemy": "./vendor/bin/alchemy setup",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withDowngradeSets(false, false, false, false, false, true)
+    ->withFluentCallNewLine()
+    ->withImportNames(true, true, true, true)
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+;

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -2,12 +2,17 @@
 
 namespace Leaf;
 
+use Exception;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use Leaf\Auth\Config;
 use Leaf\Auth\User;
+use Leaf\Exception\General;
 use Leaf\Helpers\Password;
 use Leaf\Http\Session;
+use League\OAuth2\Client\Provider\Google;
+use PDO;
+use Throwable;
 
 /**
  * Leaf Simple Auth
@@ -55,7 +60,7 @@ class Auth
             });
 
             $this->middleware('is', function ($role) {
-                \Leaf\Exception\General::error(
+                General::error(
                     '404',
                     '<p>The page you are looking for could not be found.</p>',
                     403
@@ -63,7 +68,7 @@ class Auth
             });
 
             $this->middleware('isNot', function () {
-                \Leaf\Exception\General::error(
+                General::error(
                     '404',
                     '<p>The page you are looking for could not be found.</p>',
                     403
@@ -71,7 +76,7 @@ class Auth
             });
 
             $this->middleware('can', function () {
-                \Leaf\Exception\General::error(
+                General::error(
                     '404',
                     '<p>The page you are looking for could not be found.</p>',
                     403
@@ -79,7 +84,7 @@ class Auth
             });
 
             $this->middleware('cannot', function () {
-                \Leaf\Exception\General::error(
+                General::error(
                     '404',
                     '<p>The page you are looking for could not be found.</p>',
                     403
@@ -141,10 +146,10 @@ class Auth
     /**
      * Pass in db connection instance directly
      *
-     * @param \PDO $connection A connection instance of your db
+     * @param PDO $connection A connection instance of your db
      * @return $this;
      */
-    public function dbConnection(\PDO $connection)
+    public function dbConnection(PDO $connection)
     {
         $this->db = new Db();
         $this->db->connection($connection);
@@ -174,7 +179,7 @@ class Auth
             $options['redirectUri'] = _env('APP_URL') . '/auth/google/callback';
         }
 
-        $this->withProvider($clientName, new \League\OAuth2\Client\Provider\Google(array_merge([
+        $this->withProvider($clientName, new Google(array_merge([
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,
             'redirectUri' => $options['redirectUri'],
@@ -283,8 +288,8 @@ class Auth
                 $this->errorsArray['auth'] = Config::get('messages.loginParamsError');
                 return false;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         if ($passwordKey !== false) {
@@ -350,8 +355,8 @@ class Auth
                 $this->errorsArray = array_merge($this->errorsArray, $this->db->errors());
                 return false;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         $user = $this->db->select($table)->where($userData)->first();
@@ -420,8 +425,8 @@ class Auth
                 $this->errorsArray = array_merge($this->errorsArray, $this->db->errors());
                 return false;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         if (Config::get('session')) {
@@ -483,8 +488,8 @@ class Auth
                 $this->errorsArray = array_merge($this->errorsArray, $this->db->errors());
                 return false;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         $this->user->{$passwordKey} = $newPassword;
@@ -592,8 +597,8 @@ class Auth
                 $this->errorsArray = array_merge($this->errorsArray, $this->db->errors());
                 return false;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         $user = $this->db->select($table)->where($userData)->first();
@@ -690,8 +695,8 @@ class Auth
                 $this->errorsArray = $this->db->errors();
                 return null;
             }
-        } catch (\Throwable $th) {
-            throw new \Exception($th->getMessage());
+        } catch (Throwable $th) {
+            throw new Exception($th->getMessage());
         }
 
         return $this->user = (new User(
@@ -736,8 +741,8 @@ class Auth
      */
     public function middleware(string $middleware, callable $callback)
     {
-        if (!class_exists(\Leaf\App::class)) {
-            throw new \Exception('This feature is only available for Leaf apps');
+        if (!class_exists(App::class)) {
+            throw new Exception('This feature is only available for Leaf apps');
         }
 
         if ($middleware === 'auth.required') {
@@ -833,7 +838,7 @@ class Auth
                 $bearerToken,
                 new Key(Config::get('token.secret'), 'HS256')
             );
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             $this->errorsArray['token'] = $th->getMessage();
             return null;
         }
@@ -875,7 +880,7 @@ class Auth
             }
 
             return $user;
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             $this->errorsArray['token'] = $th->getMessage();
             return null;
         }
@@ -894,13 +899,13 @@ class Auth
     protected function checkDbConnection(): void
     {
         if (!$this->db && function_exists('db')) {
-            if (db()->connection() instanceof \PDO || db()->autoConnect()) {
+            if (db()->connection() instanceof PDO || db()->autoConnect()) {
                 $this->db = db();
             }
         }
 
         if (!$this->db) {
-            throw new \Exception('You need to connect to your database first');
+            throw new Exception('You need to connect to your database first');
         }
     }
 
@@ -916,7 +921,7 @@ class Auth
     protected function sessionCheck()
     {
         if (!Config::get('session')) {
-            throw new \Exception('Turn on sessions to use this feature.');
+            throw new Exception('Turn on sessions to use this feature.');
         }
     }
 

--- a/src/Auth/Model.php
+++ b/src/Auth/Model.php
@@ -2,6 +2,8 @@
 
 namespace Leaf\Auth;
 
+use Leaf\Date;
+use Leaf\Db;
 use PDOStatement;
 
 /**
@@ -27,7 +29,7 @@ class Model
     /**
      * DB connection
      */
-    protected \Leaf\Db $db;
+    protected Db $db;
 
     /**
      * User data to save
@@ -53,7 +55,7 @@ class Model
         $data['user_id'] = $this->user->id();
 
         if (Config::get('timestamps')) {
-            $now = (new \Leaf\Date())->tick()->format(Config::get('timestamps.format'));
+            $now = (new Date())->tick()->format(Config::get('timestamps.format'));
             $data['created_at'] = $now;
             $data['updated_at'] = $now;
         }
@@ -66,11 +68,11 @@ class Model
      *
      * @param array $data Data to be updated
      *
-     * @return \Leaf\Db
+     * @return Db
      */
-    public function update(array $data): \Leaf\Db
+    public function update(array $data): Db
     {
-        $data['updated_at'] = (new \Leaf\Date())->tick()->format(Config::get('timestamps.format'));
+        $data['updated_at'] = (new Date())->tick()->format(Config::get('timestamps.format'));
 
         return $this->db->update($this->table)
             ->params($data)
@@ -80,9 +82,9 @@ class Model
     /**
      * Delete a model resource
      *
-     * @return \Leaf\Db
+     * @return Db
      */
-    public function delete(): \Leaf\Db
+    public function delete(): Db
     {
         return $this->db->delete($this->table)
             ->where('user_id', $this->user->id());
@@ -93,9 +95,9 @@ class Model
      *
      * @param string $columns Columns to search by separated by commas or *
      *
-     * @return \Leaf\Db
+     * @return Db
      */
-    public function table($columns = '*'): \Leaf\Db
+    public function table($columns = '*'): Db
     {
         return $this->db->select($this->table, $columns)
             ->where('user_id', $this->user->id());

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -2,8 +2,11 @@
 
 namespace Leaf\Auth;
 
+use Exception;
 use Firebase\JWT\JWT;
+use Leaf\Db;
 use Leaf\Http\Session;
+use Throwable;
 
 /**
  * Auth User
@@ -20,7 +23,7 @@ class User
 
     /**
      * Internal instance of Leaf database
-     * @var \Leaf\DB
+     * @var Db
      */
     protected $db;
 
@@ -69,7 +72,7 @@ class User
                     $sessionLifetime = strtotime($sessionLifetime);
 
                     if (!$sessionLifetime) {
-                        throw new \Exception('Invalid session lifetime');
+                        throw new Exception('Invalid session lifetime');
                     }
                 } else {
                     $sessionLifetime = time() + $sessionLifetime;
@@ -209,7 +212,7 @@ class User
                 ->execute();
 
             return true;
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             return false;
         }
     }
@@ -243,7 +246,7 @@ class User
 
     /**
      * Set user db instance
-     * @param \Leaf\Db $db
+     * @param Db $db
      * @return User
      */
     public function setDb($db)
@@ -293,14 +296,14 @@ class User
      *
      * @param mixed $method The table to relate to
      * @param mixed $args
-     * @throws \Exception
+     * @throws Exception
      *
      * @return Model
      */
     public function __call($method, $args)
     {
         if (!class_exists('Leaf\App')) {
-            throw new \Exception('Relations are only available in Leaf apps.');
+            throw new Exception('Relations are only available in Leaf apps.');
         }
 
         return (new Model([

--- a/src/Auth/UsesRoles.php
+++ b/src/Auth/UsesRoles.php
@@ -2,6 +2,8 @@
 
 namespace Leaf\Auth;
 
+use Throwable;
+
 /**
  * Functionality for user permissions
  * ----
@@ -46,7 +48,7 @@ trait UsesRoles
                 ])
                 ->where(Config::get('id.key'), $this->data[Config::get('id.key')])
                 ->execute();
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             return false;
         }
 

--- a/src/Auth/UsesSubscriptions.php
+++ b/src/Auth/UsesSubscriptions.php
@@ -2,6 +2,8 @@
 
 namespace Leaf\Auth;
 
+use Leaf\Billing\Subscription;
+
 /**
  * Functionality for user subscriptions
  * ----
@@ -50,7 +52,7 @@ trait UsesSubscriptions
      */
     public function hasSubscription(): bool
     {
-        return $this->subscription() && $this->subscription['status'] !== \Leaf\Billing\Subscription::STATUS_CANCELLED;
+        return $this->subscription() && $this->subscription['status'] !== Subscription::STATUS_CANCELLED;
     }
 
     /**
@@ -59,7 +61,7 @@ trait UsesSubscriptions
      */
     public function hasActiveSubscription(): bool
     {
-        return $this->subscription() && ($this->subscription['status'] === \Leaf\Billing\Subscription::STATUS_ACTIVE || $this->subscription['status'] === \Leaf\Billing\Subscription::STATUS_TRIAL);
+        return $this->subscription() && ($this->subscription['status'] === Subscription::STATUS_ACTIVE || $this->subscription['status'] === Subscription::STATUS_TRIAL);
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,8 @@
 <?php
 
+use Leaf\Auth;
+use Leaf\Config;
+
 if (!function_exists('auth') && class_exists('Leaf\App')) {
     /**
      * Return the leaf auth object
@@ -8,12 +11,12 @@ if (!function_exists('auth') && class_exists('Leaf\App')) {
      */
     function auth()
     {
-        if (!(\Leaf\Config::getStatic('auth'))) {
-            \Leaf\Config::singleton('auth', function () {
-                return new \Leaf\Auth();
+        if (!(Config::getStatic('auth'))) {
+            Config::singleton('auth', function () {
+                return new Auth();
             });
         }
 
-        return \Leaf\Config::get('auth');
+        return Config::get('auth');
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Leaf\Auth;
+use Leaf\Db;
+
 dataset('test-user', [[[
     'username' => 'test-user',
     'email' => 'test-user@example.com',
@@ -18,22 +21,22 @@ function getDatabaseConnection(): array
     ];
 }
 
-function dbInstance(): \Leaf\Db
+function dbInstance(): Db
 {
-    $db = new \Leaf\Db();
+    $db = new Db();
 
     try {
         $db->connect(getDatabaseConnection());
-    } catch (\Throwable $th) {
+    } catch (Throwable $th) {
         throw $th;
     }
 
     return $db;
 }
 
-function authInstance(): \Leaf\Auth
+function authInstance(): Auth
 {
-    $auth = new \Leaf\Auth();
+    $auth = new Auth();
     $auth->dbConnection(dbInstance()->connection());
 
     return $auth;
@@ -41,7 +44,7 @@ function authInstance(): \Leaf\Auth
 
 function deleteUser(string $username, $table = 'users')
 {
-    $db = new \Leaf\Db();
+    $db = new Db();
     $db->connect(getDatabaseConnection());
 
     $db->delete($table)->where('username', $username)->execute();
@@ -64,7 +67,7 @@ function createTableForUsers($table = 'users'): void
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )")
             ->execute();
-    } catch (\Throwable $th) {
-        throw new \Exception('Failed to create table for users: ' . $th->getMessage());
+    } catch (Throwable $th) {
+        throw new Exception('Failed to create table for users: ' . $th->getMessage());
     }
 }

--- a/tests/login.test.php
+++ b/tests/login.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Leaf\Auth\User;
+
 beforeAll(function () {
     createTableForUsers();
 
@@ -12,7 +14,7 @@ beforeAll(function () {
                 'password' => password_hash('password', PASSWORD_BCRYPT)
             ])
             ->execute();
-    } catch (\Throwable $th) {
+    } catch (Throwable $th) {
         throw $th;
     }
 });
@@ -33,7 +35,7 @@ test('user can login', function () {
     $success = $auth->login($testUser);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($testUser['username']);
 });
 
@@ -100,7 +102,7 @@ test('login should work without password is password.key is false', function () 
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     $auth->config('password.key', 'password');

--- a/tests/register.test.php
+++ b/tests/register.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Leaf\Auth\User;
+
 beforeAll(function () {
     createTableForUsers();
     dbInstance()->delete('users')->execute();
@@ -26,7 +28,7 @@ test('user can register an account', function () {
     }
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 });
 
@@ -47,7 +49,7 @@ test('user can login after registering', function () {
     $loginSuccess = $auth->login($userData);
 
     expect($loginSuccess)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 });
 

--- a/tests/session.test.php
+++ b/tests/session.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Leaf\Auth\User;
+
 beforeAll(function () {
     createTableForUsers();
     dbInstance()->delete('users')->execute();
@@ -30,7 +32,7 @@ test('register should create a new session when session => true', function () {
     $success = $auth->register($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -51,7 +53,7 @@ test('register should not create a new session when session => false', function 
     $success = $auth->register($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
 
     expect(session_status())->toBe(PHP_SESSION_NONE);
     expect($_SESSION['auth']['user']['username'] ?? null)->toBeNull();
@@ -71,7 +73,7 @@ test('login should create session when session => true', function () {
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -94,7 +96,7 @@ test('session should create auth.ttl when session.lifetime is not 0', function (
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -117,7 +119,7 @@ test('session should not create auth.ttl when session.lifetime is 0', function (
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -140,7 +142,7 @@ test('session should expire after session.lifetime', function () {
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -172,7 +174,7 @@ test('login should regenerate session id when session => true and session is alr
     $newSessionId = session_id();
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($userData['username']);
 
     expect(session_status())->toBe(PHP_SESSION_ACTIVE);
@@ -195,7 +197,7 @@ test('logout should remove auth info from session when session => true', functio
     $success = $auth->login($userData);
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($_SESSION['auth']['user']['username'] ?? null)->toBe($userData['username']);
 
     $auth->logout();

--- a/tests/user.test.php
+++ b/tests/user.test.php
@@ -1,5 +1,8 @@
 <?php
 
+use Leaf\Auth;
+use Leaf\Auth\User;
+
 beforeAll(function () {
     createTableForUsers();
     dbInstance()->delete('users')->execute();
@@ -13,7 +16,7 @@ beforeAll(function () {
                 'password' => password_hash('password', PASSWORD_BCRYPT)
             ])
             ->execute();
-    } catch (\Throwable $th) {
+    } catch (Throwable $th) {
         throw $th;
     }
 });
@@ -39,7 +42,7 @@ test('auth user is instance of Leaf\Auth\User', function () {
     }
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($testUser['username']);
 });
 
@@ -60,11 +63,11 @@ test('logout can use logout callback to run custom action', function () {
     }
 
     expect($success)->toBeTrue();
-    expect($auth->user())->toBeInstanceOf(\Leaf\Auth\User::class);
+    expect($auth->user())->toBeInstanceOf(User::class);
     expect($auth->user()->username)->toBe($testUser['username']);
 
     $auth->logout(function ($auth) use ($testUser) {
-        expect($auth)->toBeInstanceOf(\Leaf\Auth::class);
+        expect($auth)->toBeInstanceOf(Auth::class);
     });
 
     expect($auth->user())->toBeNull();


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [ ] Feature
- [X] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->
Rector php allows many refactors, one of them is replace \ClassName with use Classname, added in php 5.3

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [X] No
