### PR TITLE
feat: allow callable for ids on register

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -337,7 +337,7 @@ class Auth
             $userData['email'] = strtolower($userData['email']);
         }
 
-        if (isset($credentials[Config::get('id.key')])) {
+        if (isset($userData[Config::get('id.key')])) {
             $userData[Config::get('id.key')] = is_callable($userData[Config::get('id.key')])
                 ? call_user_func($userData[Config::get('id.key')])
                 : $userData[Config::get('id.key')];
@@ -579,7 +579,7 @@ class Auth
             $userData['email'] = strtolower($userData['email']);
         }
 
-        if (isset($credentials[Config::get('id.key')])) {
+        if (isset($userData[Config::get('id.key')])) {
             $userData[Config::get('id.key')] = is_callable($userData[Config::get('id.key')])
                 ? call_user_func($userData[Config::get('id.key')])
                 : $userData[Config::get('id.key')];


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->
There was a dead code in Auth::register and Auth::createUserFor because $credentials is not defined, using $userData allows to execute possible callables passed as id.

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [X] No

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Before
```php
$auth = new Leaf\Auth;

$auth->register([
  'id' => static fn(): string => uniqid(),
]); // Object of class Closure could not be converted to string
```

After
```php
$auth = new Leaf\Auth;

$auth->register([
  'id' => static fn(): string => 'abc',
]);

echo $auth->id(); // 'abc';
```