### PR TITLE
Move test db connection to env

### DIFF
--- a/.env.example.php
+++ b/.env.example.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'DB_CONNECTION' => 'pgsql',
+    'DB_PORT' => 6543,
+    'DB_HOST' => 'aws-1-eu-west-2.pooler.supabase.com',
+    'DB_USERNAME' => 'postgres.vljhbheaihorcnvlkljw',
+    'DB_PASSWORD' => 'DV!GE7Aq6C8F55g',
+    'DB_DATABASE' => 'postgres',
+];

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ vendor/
 test/
 old/
 *.tests.php
+.env.php
+*.sqlit*
 
 # OS Generated
 .DS_Store*

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,13 +11,19 @@ dataset('test-user', [[[
 
 function getDatabaseConnection(): array
 {
+    if (file_exists(__DIR__ . '/../.env.php')) {
+        $_ENV = require __DIR__ . '/../.env.php';
+    }
+
+    $_ENV += require __DIR__ . '/../.env.example.php';
+
     return [
-        'dbtype' => 'pgsql',
-        'port' => '6543',
-        'host' => 'aws-1-eu-west-2.pooler.supabase.com',
-        'username' => 'postgres.vljhbheaihorcnvlkljw',
-        'password' => 'DV!GE7Aq6C8F55g',
-        'dbname' => 'postgres',
+        'dbtype' => $_ENV['DB_CONNECTION'],
+        'port' => $_ENV['DB_PORT'],
+        'host' => $_ENV['DB_HOST'],
+        'username' => $_ENV['DB_USERNAME'],
+        'password' => $_ENV['DB_PASSWORD'],
+        'dbname' => $_ENV['DB_DATABASE'],
     ];
 }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -55,18 +55,34 @@ function createTableForUsers($table = 'users'): void
     $db = dbInstance();
 
     try {
-        $db
-            ->query("CREATE TABLE IF NOT EXISTS $table (
-                id SERIAL PRIMARY KEY,
-                username VARCHAR(255) NOT NULL,
-                email VARCHAR(255) NOT NULL,
-                password VARCHAR(255) NOT NULL,
-                permissions JSONB,
-                roles JSONB,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )")
-            ->execute();
+        switch ($_ENV['DB_CONNECTION']) {
+            case 'mysql':
+                $sql = "CREATE TABLE IF NOT EXISTS $table (
+                    id SERIAL PRIMARY KEY,
+                    username VARCHAR(255) NOT NULL,
+                    email VARCHAR(255) NOT NULL,
+                    password VARCHAR(255) NOT NULL,
+                    permissions JSON,
+                    roles JSON,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )";
+                break;
+
+            default:
+                $sql = "CREATE TABLE IF NOT EXISTS $table (
+                    id SERIAL PRIMARY KEY,
+                    username VARCHAR(255) NOT NULL,
+                    email VARCHAR(255) NOT NULL,
+                    password VARCHAR(255) NOT NULL,
+                    permissions JSONB,
+                    roles JSONB,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )";
+        }
+
+        $db->query($sql)->execute();
     } catch (Throwable $th) {
         throw new Exception('Failed to create table for users: ' . $th->getMessage());
     }


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [x] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->

This pull request introduces environment-based configuration for database connection settings and updates the test utilities to use these settings dynamically. The changes improve flexibility for different environments and add support for both PostgreSQL and MySQL in test table creation.

Configuration improvements:

* Added a new `.env.example.php` file containing default database connection settings as a PHP array, providing a template for environment-specific configuration.
* Updated `tests/Pest.php` to load database configuration from `.env.php` if present, falling back to `.env.example.php`, and to use these values when establishing the database connection.

Test database compatibility:

* Modified the `createTableForUsers` function in `tests/Pest.php` to generate the appropriate SQL for table creation based on the `DB_CONNECTION` environment variable, supporting both MySQL and PostgreSQL (with differences in JSON/JSONB column types). [[1]](diffhunk://#diff-f1690c87bfa8aecd216efde2439aa080c5ec7e9439abd4ea7a2483489fc8a6f5L58-R79) [[2]](diffhunk://#diff-f1690c87bfa8aecd216efde2439aa080c5ec7e9439abd4ea7a2483489fc8a6f5L68-R91)

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No